### PR TITLE
Initial pt-br for announcements section

### DIFF
--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -100,18 +100,18 @@
     "copySuccess": "XML copiado para a Área de transferência"
   },
   "announcements": {
-    "noRoasOrAnnouncements": "No ROAs or Announcements found.",
-    "search": "Search for ASN, prefix, state...",
-    "showBGPInfo": "Show BGP info",
-    "authorizes": "Authorizes {number} announcements",
-    "disallows": "Disallows {number} announcements",
+    "noRoasOrAnnouncements": "ROAs ou Anúncios não encontrados.",
+    "search": "Pesquisar por ASN, prefixos, estados...",
+    "showBGPInfo": "Mostrar informações BGP",
+    "authorizes": "Autoriza {number} anúncio(s)",
+    "disallows": "Desabilita {number} anúncio(s)",
     "state": {
-      "roa_seen": "SEEN",
-      "announcement_not_found": "NOT FOUND",
-      "roa_stale": "STALE",
-      "announcement_invalid_length": "INVALID LENGTH POTATO",
-      "announcement_invalid_asn": "INVALID ASN",
-      "roa_no_announcement_info": "NO ANNOUNCEMENT INFO"
+      "roa_seen": "VISTO",
+      "announcement_not_found": "NÃO ENCONTRADO",
+      "roa_stale": "OBSOLETO",
+      "announcement_invalid_length": "COMPRIMENTO INVÁLIDO",
+      "announcement_invalid_asn": "ASN INVÁLIDO",
+      "roa_no_announcement_info": "SEM INFORMAÇÕES DE ANÚNCIO"
     }
   },
   "errors": {


### PR DESCRIPTION
I have a question regarding roa_seen label.

The original "SEEN" in roa_seen label can be translated to "VISTO", but I'm not sure if it fits in this context. Usually seen is related to some event occurred in the past, but we don't have any date/time event related, such as "latest date/time seen".

Does the label "SEEN" refer to the term "VALID ROAs"?

One missing thing is the label 'Prefix' ('State' is missing too) used in some header tables, and also while adding a ROA.

Thanks & regards,