### PR TITLE
New api error strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note that you'll have the reroute the `/api`, `/auth` and `/stats` endpoints to 
 
 For example:
 
-```json
+```javascript
 ...
   devServer: {
     // Krill proxy instance (for API calls).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,11 +2098,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+        }
       }
     },
     "babel-code-frame": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -224,6 +224,8 @@
     "api-insufficient-rights": "Your user does not have sufficient rights to perform this action. Please contact your administrator.",
     "api-invalid-credentials": "The supplied login credentials were incorrect.",
     "api-auth-error": "An error occurred while logging you in: {cause}",
+    "api-auth-transient-error": "A (temporary) error occured while trying to authenticate your request. Please try again later.",
+    "api-auth-permanent-error": "An error occurred while trying to authenticate your request. Please contact your administrator.",
     "general-error": "Something went wrong. Please contact your administrator."
   },
   "testbed": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -223,9 +223,10 @@
     "ca-roa-delta-error": "ROA rejected because of the following issue(s)",
     "api-insufficient-rights": "Your user does not have sufficient rights to perform this action. Please contact your administrator.",
     "api-invalid-credentials": "The supplied login credentials were incorrect.",
-    "api-auth-error": "An error occurred while logging you in: {cause}",
+    "api-login-error": "An error occurred while logging you in: {cause}",
     "api-auth-transient-error": "A (temporary) error occured while trying to authenticate your request. Please try again later.",
     "api-auth-permanent-error": "An error occurred while trying to authenticate your request. Please contact your administrator.",
+    "api-auth-session-expired": "Your login session has expired. Please login again..",
     "general-error": "Something went wrong. Please contact your administrator."
   },
   "testbed": {


### PR DESCRIPTION
Goes with krill PR #396 [https://github.com/NLnetLabs/krill/pull/396/files/3a60fb621e7aa67d7e0217173428e94bbd084f03.](https://github.com/NLnetLabs/krill/pull/396/files/3a60fb621e7aa67d7e0217173428e94bbd084f03.) [](https://github.com/NLnetLabs/krill/pull/396/files/3a60fb621e7aa67d7e0217173428e94bbd084f03) That creates two new error labels, `api-auth-permanent-error` and `api-auth-transient-error`. These two errors will only happen after trying to refresh a token or authenticating a request, **not** at login time.